### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/test/vundle.fish
+++ b/test/vundle.fish
@@ -1,1 +1,1 @@
-test available vundle
+test type -q vundle


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
