### PR TITLE
Add options for setting the location of Vundle.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Runs PluginUpdate to install missing plugins and update out of date plugins
 
 Runs PluginClean! to remove unused plugins
 
+## Configuration
+
+By default the vundle plugin checks if vundle is installed by looking for
+`$HOME/.vim/bundle/Vundle.vim`. You can customize this with the following
+options:
+
+```fish
+# Set the vim runtime path
+set -g plugin_vundle_runtimepath $HOME/.vim
+# The directory within the runtimepath where plugins are stored
+set -g plugin_vundle_plugin_dir bundle
+```
+
 # License
 
 [MIT][mit] © [nwykes][author] et [al][contributors]

--- a/init.fish
+++ b/init.fish
@@ -1,4 +1,10 @@
-if [ ! -e ~/.vim/bundle/Vundle.vim/.git ]
+set -q plugin_vundle_runtimepath
+    or set -l plugin_vundle_runtimepath $HOME/.vim
+
+set -q plugin_vundle_plugin_dir
+    or set -l plugin_vundle_plugin_dir $plugin_vundle_runtimepath/bundle
+
+if [ ! -e "$plugin_vundle_plugin_dir/Vundle.vim/.git" ]
   echo \n\t "Vundle.vim is not installed."
   echo \n\t "Read about vim configuration for vundle at https://github.com/VundleVim/Vundle.Vim" \n
 end


### PR DESCRIPTION
Adds two options, one for setting the vim runtimepath and one for
setting the directory within the runtimepath where plugins are cloned.